### PR TITLE
added xarrayutils to ci envs

### DIFF
--- a/ci/environment-py3.7.yml
+++ b/ci/environment-py3.7.yml
@@ -8,6 +8,7 @@ dependencies:
   - scipy
   - xarray
   - cmip6_preprocessing
+  - xarrayutils
   - regionmask
   ##############
   - pytest

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -8,6 +8,7 @@ dependencies:
   - scipy
   - xarray
   - cmip6_preprocessing
+  - xarrayutils
   - regionmask
   ##############
   - pytest


### PR DESCRIPTION
Used xarrayutils.dll_dist as part of a test. Are you okay with referencing this sort of thing in tests, or should they be more 'manual'? @jbusecke  