### PR TITLE
Test for muli threshold case + fix bug with upper/lower boundary.

### DIFF
--- a/cmip6_omz/boundaries.py
+++ b/cmip6_omz/boundaries.py
@@ -38,19 +38,30 @@ def _find_boundaries(z, o2, threshold, output_size, output):
             forward_idx = idx
             pass
 
-    backward_o2 = o2[backward_idx : min_idx + 1]
-    backward_z = z[backward_idx : min_idx + 1]
-    forward_o2 = o2[min_idx : forward_idx + 1]
-    forward_z = z[min_idx : forward_idx + 1]
-
     def sort_and_interp(th, o2, z):
         if o2[-1] < o2[0]:
             o2 = o2[::-1]
             z = z[::-1]
         return np.interp(th, o2, z)
 
-    back_z = sort_and_interp(threshold, backward_o2, backward_z)
-    forw_z = sort_and_interp(threshold, forward_o2, forward_z)
+    # if the indexes are still equal to `min_idx` it means
+    # that in this direction there was no value smaller than threshold
+    # in that case the omz extends to the bottom/top and the values should be set to nan
+    if backward_idx == min_idx:
+        back_z = np.nan
+
+    else:
+        backward_o2 = o2[backward_idx : min_idx + 1]
+        backward_z = z[backward_idx : min_idx + 1]
+        back_z = sort_and_interp(threshold, backward_o2, backward_z)
+
+    if forward_idx == min_idx:
+        forw_z = np.nan
+    else:
+        forward_o2 = o2[min_idx : forward_idx + 1]
+        forward_z = z[min_idx : forward_idx + 1]
+        forw_z = sort_and_interp(threshold, forward_o2, forward_z)
+
     output[2] = back_z
     output[3] = forw_z
 

--- a/tests/test_boundaries.py
+++ b/tests/test_boundaries.py
@@ -25,3 +25,76 @@ def test_omz_boundaries(vertical_dim):
     )
 
     xr.testing.assert_allclose(expected, omz_bounds)
+
+
+@pytest.mark.parametrize("vertical_dim", ["lev", "something"])
+def test_omz_boundaries_muli_threshold(vertical_dim):
+    # This is not an efficient way to do this, but should work for now
+    # This basically calls the boundary function for each o2_threshold
+    z_raw = np.arange(10) * 3
+    o2_raw = np.array([14.0, 13, 12, 10, 0, 3, 0, 2, 2, 3])
+    th = np.array([2.7, 5.0, 16])
+    th = xr.DataArray(th, dims="o2_threshold", coords={"o2_threshold": th})
+
+    o2 = xr.DataArray(
+        o2_raw, dims=[vertical_dim], coords={vertical_dim: z_raw}
+    ).expand_dims({"x": 3})
+
+    omz_bounds = omz_boundaries(o2[vertical_dim], o2, th, vertical_dim=vertical_dim)
+
+    expected_coords = {"o2_threshold": th}
+    expected = xr.Dataset(
+        {
+            # This is one of the confusing parts of the output.
+            # These values here are the same for each threshold
+            # and should ideally not be repeated
+            f"o2_min_{vertical_dim}": xr.DataArray(
+                [12.0, 12.0, 12.0], dims=["o2_threshold"]
+            ).expand_dims({"x": 3}),
+            "o2_min_value": xr.DataArray(
+                [0.0, 0.0, 0.0], dims=["o2_threshold"]
+            ).expand_dims({"x": 3}),
+            "upper_boundary": xr.DataArray(
+                [11.19, 10.5, np.nan],
+                dims=["o2_threshold"],
+                coords=expected_coords,
+            ).expand_dims({"x": 3}),
+            "lower_boundary": xr.DataArray(
+                [14.7, np.nan, np.nan],
+                dims=["o2_threshold"],
+                coords=expected_coords,
+            ).expand_dims({"x": 3}),
+        }
+    )
+
+    xr.testing.assert_allclose(expected, omz_bounds)
+
+
+# def test_omz_boundaries_mulitple(vertical_dim):
+#     # THIS is how I would want it to work
+#     z_raw = np.arange(10) * 3
+#     o2_raw = np.array([14.0, 13, 12, 10, 0, 3, 0, 2, 2, 3])
+#     th = np.array([1.2, 2.7, 5.8])
+#     th = xr.DataArray(th, dims="o2_threshold", coords={"o2_threshold": th})
+
+#     o2 = xr.DataArray(
+#         o2_raw, dims=[vertical_dim], coords={vertical_dim: z_raw}
+#     ).expand_dims({"x": 3})
+
+#     omz_bounds = omz_boundaries(o2[vertical_dim], o2, th, vertical_dim=vertical_dim)
+
+#     expected_coords = {"o2_threshold": th}
+#     expected = xr.Dataset(
+#         {
+#             f"o2_min_{vertical_dim}": xr.DataArray(12.0).expand_dims({"x": 3}),
+#             "o2_min_value": xr.DataArray(0.0).expand_dims({"x": 3}),
+#             "upper_boundary": xr.DataArray(
+#                 [11.19, np.nan, np.nan], dims=["o2_threshold"], coords=expected_coords
+#             ).expand_dims({"x": 3}),
+#             "lower_boundary": xr.DataArray(
+#                 [14.7, np.nan, np.nan], dims=["o2_threshold"], coords=expected_coords
+#             ).expand_dims({"x": 3}),
+#         }
+#     )
+
+#     xr.testing.assert_allclose(expected, omz_bounds)


### PR DESCRIPTION
The old version did not deal properly with cases where none of the watercolumn was above the given threshold (omz expands all the way to the surface or bottom). This sets values to nan in such a case.